### PR TITLE
Add delivery dates to invoice

### DIFF
--- a/manager/src/commonMain/kotlin/de/openindex/zugferd/manager/model/Invoice.kt
+++ b/manager/src/commonMain/kotlin/de/openindex/zugferd/manager/model/Invoice.kt
@@ -40,6 +40,8 @@ data class Invoice(
     val number: String = "",
     val issueDate: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
     val dueDate: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()).plus(DatePeriod(days = 14)),
+    val deliveryStartDate: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+    val deliveryEndDate: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
     val sender: TradeParty? = null,
     val recipient: TradeParty? = null,
     val currency: String = DEFAULT_CURRENCY,

--- a/manager/src/commonMain/kotlin/de/openindex/zugferd/manager/sections/CreateSection.kt
+++ b/manager/src/commonMain/kotlin/de/openindex/zugferd/manager/sections/CreateSection.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
+import androidx.compose.material3.DatePicker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -529,7 +530,40 @@ private fun ColumnScope.GeneralForm(state: CreateSectionState) {
                     )
                 }
             }
-        }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .fillMaxWidth(),
+            ) {
+                DateField(
+                    label = "Startdatum der Leistung*",
+                    value = state.deliveryStartDate,
+                    onValueChange = { state.deliveryStartDate = it ?: state.deliveryStartDate },
+                    modifier = Modifier
+                        .weight(0.5f, true),
+                )
+
+                DateField(
+                    label = "Enddatum der Leistung*",
+                    value = state.deliveryEndDate,
+                    onValueChange = { state.deliveryEndDate = it ?: state.deliveryEndDate },
+                    modifier = Modifier
+                        .weight(0.5f, true),
+                )
+
+                // HACK: Show hidden button to ensure equal width of input fields.
+                IconButton(
+                    onClick = {},
+                    modifier = Modifier
+                        .alpha(0f)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.QuestionMark,
+                        contentDescription = "Nichts zu tun",
+                    )
+                }
+            }        }
 
         Column(
             verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/manager/src/commonMain/kotlin/de/openindex/zugferd/manager/sections/CreateSectionState.kt
+++ b/manager/src/commonMain/kotlin/de/openindex/zugferd/manager/sections/CreateSectionState.kt
@@ -206,6 +206,16 @@ class CreateSectionState : SectionState() {
         set(value) {
             _invoice.value = _invoice.value.copy(dueDate = value)
         }
+    var deliveryStartDate: LocalDate
+        get() = _invoice.value.deliveryStartDate
+        set(value) {
+            _invoice.value = _invoice.value.copy(deliveryStartDate = value)
+        }
+    var deliveryEndDate: LocalDate
+        get() = _invoice.value.deliveryEndDate
+        set(value) {
+            _invoice.value = _invoice.value.copy(deliveryEndDate = value)
+        }
     var invoiceSender: TradeParty?
         get() = _invoice.value.sender
         set(value) {

--- a/manager/src/desktopMain/kotlin/de/openindex/zugferd/manager/model/Invoice.desktop.kt
+++ b/manager/src/desktopMain/kotlin/de/openindex/zugferd/manager/model/Invoice.desktop.kt
@@ -49,6 +49,8 @@ fun Invoice.build(method: PaymentMethod): _Invoice {
         .setNumber(number)
         .setIssueDate(issueDate.toJavaDate())
         .setDueDate(dueDate.toJavaDate())
+        .setDeliveryDate(deliveryEndDate.toJavaDate())
+        .setDetailedDeliveryPeriod(deliveryStartDate.toJavaDate(), deliveryEndDate.toJavaDate())
         .setPaymentTermDescription(
             if (method == PaymentMethod.SEPA_DIRECT_DEBIT)
                 "Abbuchung erfolgt am ${DATE_FORMAT.format(dueDate.toJavaDate())}."


### PR DESCRIPTION
Some validators complain if the delivery date is missing from the invoice, since this is a legal requirement ("Leistungszeitraum"). This branch therefore adds two date fields containing the delivery date (from/to).